### PR TITLE
Fix GCode Movement Bug

### DIFF
--- a/js/simulator.js
+++ b/js/simulator.js
@@ -283,6 +283,15 @@ Simulator.prototype.addGcodeCircle = function (cols, start, end, lineType) {
   var endAngle = Math.atan2(endPointY - centerY, endPointX - centerX);
   sweepAngle = startVec.angleTo(endVec);
 
+  var arcLength = sweepAngle * radius;
+  if (arcLength < 20) {
+    // Arcの長さが小さい場合はLineとする
+    geometry.vertices.push(start, end);  
+    var line = new THREE.Line(geometry, material);
+    this.toolpath.add(line);
+    return;    
+  }
+
   if (direction > 0) {
     // G2 CW
     sweepAngle = -sweepAngle;  
@@ -450,8 +459,8 @@ Simulator.prototype.loadSbp = function (data) {
       currentPosition.copy(end);  
       var point = currentPosition.clone();
       this.addGcodeCircle(cols, start, end, lineType);
-      point.lineType = lineType;
-      this.points.push(point);
+      //point.lineType = lineType;
+      //this.points.push(point);
           
     }
 


### PR DESCRIPTION
CGのARCが小さい時に ThreeJSの Geometryが作成できないバッグがありますので
Arcが小さい場合は線として考えてGeometryを作成するようにしました。
<img width="596" alt="gcodeDebug" src="https://github.com/vuildjp/shopbot-simulator/assets/161716878/012f4218-6f13-414d-938b-35d673e0d267">
<img width="626" alt="gcodeDebug2" src="https://github.com/vuildjp/shopbot-simulator/assets/161716878/00b2ef49-da61-45ea-ba9d-307db4b0c1c5">
